### PR TITLE
Update standings_template.php

### DIFF
--- a/config/standings_template.php
+++ b/config/standings_template.php
@@ -34,5 +34,14 @@ return [
             //
         ],
     ],
+    
+    'reds' => [
+        'alliances' => [
+            //
+        ],
+        'corporations' => [
+            //
+        ],
+    ],
 
 ];


### PR DESCRIPTION
Updating the standings_template to include the reds group fixes a bug with the cron job resulting in an exception. This exception appears when run against a user that is not in holder, blues or light-blues as the next check in line is reds.
